### PR TITLE
Update POMs for publishing to Maven central.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+script:
+  - mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
+before_install:
+install:
 script:
-  - mvn package
+  - mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-before_install:
 install:
+  - cd bundle && mvn dependency:resolve
 script:
   - mvn clean package

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -140,11 +140,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                 <configuration>
-                    <excludePackageNames>
-                        *.impl
-                    </excludePackageNames>
-                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/bundle/src/main/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServlet.java
+++ b/bundle/src/main/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServlet.java
@@ -24,15 +24,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Servlet used to execute Sling Health Checks based on provided tags (if no tags 
+ * Servlet used to execute Sling Health Checks based on provided tags (if no tags
  * are provided, all registered health checks will be executed).
- * 
+ *
  * Sample requests:
  * /system/health
  * /system/health?tags=devops
  * /system/health?tags=devops,security
- * /system/health?tags=devops,security&combineTagsOr=false
- * 
+ * /system/health?tags=devops,security&amp;combineTagsOr=false
+ *
  * Sample response:
  * {
  *   "results": [
@@ -43,11 +43,11 @@ import org.slf4j.LoggerFactory;
  *       }
  *   ]
  * }
- * 
- * 
- * Note: It is assumed that all /system/* paths are only accessible from a local 
+ *
+ *
+ * Note: It is assumed that all /system/* paths are only accessible from a local
  * network and not routed to the Internet.
- * 
+ *
  * More information:
  * https://sling.apache.org/documentation/bundles/sling-health-check-tool.html
  */
@@ -58,41 +58,41 @@ import org.slf4j.LoggerFactory;
     paths = {"/system/health"}
 )
 public class HealthCheckExecutorServlet extends SlingSafeMethodsServlet {
-    
+
     @Reference
     protected HealthCheckExecutor healthCheckExecutor;
-    
+
     private static final String PARAM_TAGS = "tags";
     private static final String PARAM_COMBINE_TAGS_OR = "combineTagsOr";
-    
+
     private static final Logger logger = LoggerFactory.getLogger(HealthCheckExecutorServlet.class);
-    
+
     @Activate
     protected void activate(ComponentContext context) {
         logger.debug("Starting HealthCheckExecutorServlet");
     }
-    
+
     @Deactivate
     protected void deactivate() {
         logger.debug("Stopping HealthCheckExecutorServlet");
     }
 
     @Override
-    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) 
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
                                                         throws ServletException, IOException {
         response.setContentType("application/json");
         response.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
-        
+
         // parse query parameters
         String tagsStr = StringUtils.defaultString(request.getParameter(PARAM_TAGS));
         String[] tags = tagsStr.split("[, ;]+");
         String combineTagsOr = StringUtils.defaultString(request.getParameter(PARAM_COMBINE_TAGS_OR), "true");
-        
+
         // execute health checks
         HealthCheckExecutionOptions options = new HealthCheckExecutionOptions();
         options.setCombineTagsWithOr(Boolean.valueOf(combineTagsOr));
         List<HealthCheckExecutionResult> results = healthCheckExecutor.execute(options, tags);
-        
+
         // check results
         boolean allOk = true;
         for(HealthCheckExecutionResult result : results) {
@@ -101,14 +101,14 @@ public class HealthCheckExecutorServlet extends SlingSafeMethodsServlet {
                 break;
             }
         }
-        
+
         // set appropriate status code
         if(!allOk) {
             response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         } else {
             response.setStatus(HttpServletResponse.SC_OK);
         }
-        
+
         // write out JSON response
         JSONObject resultJson = new JSONObject();
         try {
@@ -118,13 +118,13 @@ public class HealthCheckExecutorServlet extends SlingSafeMethodsServlet {
         }
         response.getWriter().write(resultJson.toString());
     }
-    
+
     /**
      * Creates a JSON representation of the given HealthCheckExecutionResult list.
      * @param executionResults
      * @param resultJson
      * @return
-     * @throws JSONException 
+     * @throws JSONException
      */
     private static JSONObject generateResponse(List<HealthCheckExecutionResult> executionResults,
                                                 JSONObject resultJson) throws JSONException {
@@ -133,7 +133,7 @@ public class HealthCheckExecutorServlet extends SlingSafeMethodsServlet {
 
         for (HealthCheckExecutionResult healthCheckResult : executionResults) {
             JSONObject result = new JSONObject();
-            result.put("name", healthCheckResult.getHealthCheckMetadata() != null ? 
+            result.put("name", healthCheckResult.getHealthCheckMetadata() != null ?
                                healthCheckResult.getHealthCheckMetadata().getName() : "");
             result.put("status", healthCheckResult.getHealthCheckResult().getStatus());
             result.put("timeMs", healthCheckResult.getElapsedTimeInMs());

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,38 @@
 
     <name>AEM HealthCheck - Reactor Project</name>
     <description>Maven Multimodule project for AEM HealthCheck</description>
+    <url>https://github.com/shinesolutions/aem-healthcheck</url>
 
     <scm>
-        <developerConnection>scm:git:https://github.com/shinesolutions/aem-healthcheck.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git@github.com:shinesolutions/aem-healthcheck.git</connection>
+        <developerConnection>scm:git:git@github.com:shinesolutions/aem-healthcheck.git</developerConnection>
+        <url>https://github.com/shinesolutions/aem-healthcheck</url>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>sonatype-release</id>
+            <name>Sonatype Release</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+    </distributionManagement>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+     </licenses>
+
+     <developers>
+         <developer>
+             <name>Shine Solutions</name>
+             <email>opensource@shinesolutions.com</email>
+             <organization>Shine Solutions</organization>
+             <organizationUrl>http://shinesolutions.com</organizationUrl>
+         </developer>
+     </developers>
 
     <prerequisites>
         <maven>3.0.2</maven>
@@ -262,11 +289,46 @@
                             *.impl
                         </excludePackageNames>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                              <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.5</version>
+                    <executions>
+                        <execution>
+                             <id>sign-artifacts</id>
+                             <phase>verify</phase>
+                             <goals>
+                                 <goal>sign</goal>
+                             </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Travis CI is also updated to run `mvn package` so it runs all tests and verifies that artifacts can be built, otherwise it defaults to `mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V` which skips test and javadoc (we want to verify they work) and also installs the artifacts (which are now signed and will fail from a machine without proper Maven settings, so `install` is not necessary).