### PR TITLE
Added the shallow tag while keeping the devops tag for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.1.1
-* changed `devops` tag to `shallow` while keeping `devops` for backward compatibility
+* Introduced `shallow` tag. #10
+* `devops` tag will be retired in a later version
 
 ### 1.1
 * changed `groupId` to `com.shinesolutions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.2
+### 1.1.1
 * changed `devops` tag to `shallow` while keeping `devops` for backward compatibility
 
 ### 1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.2
+* changed `devops` tag to `shallow` while keeping `devops` for backward compatibility
+
 ### 1.1
 * changed `groupId` to `com.shinesolutions`
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For the full list of provided health checks in AEM, go to [http://localhost:4502
 
 Sample requests:
  * http://host:port/system/health
- * http://host:port/system/health?tags=devops
- * http://host:port/system/health?tags=devops,security
- * http://host:port/system/health?tags=devops,security&combineTagsOr=false
+ * http://host:port/system/health?tags=shallow
+ * http://host:port/system/health?tags=shallow,security
+ * http://host:port/system/health?tags=shallow,security&combineTagsOr=false
 
 Sample response:
 ```

--- a/bundle/src/main/java/com/shinesolutions/healthcheck/hc/impl/SmokeHealthCheck.java
+++ b/bundle/src/main/java/com/shinesolutions/healthcheck/hc/impl/SmokeHealthCheck.java
@@ -14,7 +14,7 @@ import org.apache.sling.hc.util.FormattingResultLog;
     name = "Smoke Health Check",
     mbeanName = "smokeHC",
     description = "This health check determines if an instance is ready to serve requests",
-    tags = {"devops"}
+    tags = {"shallow", "devops"}
 )
 public class SmokeHealthCheck implements HealthCheck {
 

--- a/bundle/src/main/java/com/shinesolutions/healthcheck/hc/impl/SmokeHealthCheck.java
+++ b/bundle/src/main/java/com/shinesolutions/healthcheck/hc/impl/SmokeHealthCheck.java
@@ -14,7 +14,7 @@ import org.apache.sling.hc.util.FormattingResultLog;
     name = "Smoke Health Check",
     mbeanName = "smokeHC",
     description = "This health check determines if an instance is ready to serve requests",
-    tags = {"shallow", "devops"}
+    tags = {"shallow", "devops", "deep"} // TODO: The deep tag is just a placeholder for when the actual healthchecks are done
 )
 public class SmokeHealthCheck implements HealthCheck {
 

--- a/bundle/src/main/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServlet.java
+++ b/bundle/src/main/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServlet.java
@@ -30,9 +30,9 @@ import org.slf4j.LoggerFactory;
  *
  * Sample requests:
  * /system/health
- * /system/health?tags=devops
- * /system/health?tags=devops,security
- * /system/health?tags=devops,security&amp;combineTagsOr=false
+ * /system/health?tags=shallow
+ * /system/health?tags=shallow,security
+ * /system/health?tags=shallow,security&amp;combineTagsOr=false
  *
  * Sample response:
  * {

--- a/bundle/src/test/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServletTest.java
+++ b/bundle/src/test/java/com/shinesolutions/healthcheck/servlets/HealthCheckExecutorServletTest.java
@@ -92,14 +92,14 @@ public class HealthCheckExecutorServletTest {
     }
     
     /**
-     * /system/health?tags=devops
+     * /system/health?tags=shallow
      */
     @Test
     public void testSingleTagAndOneResult() throws Exception {
         List<HealthCheckExecutionResult> results = new ArrayList<>();
         results.add(new TestHealthCheckResult());
         
-        when(mockRequest.getParameter("tags")).thenReturn("devops");
+        when(mockRequest.getParameter("tags")).thenReturn("shallow");
         when(mockRequest.getParameter("combineTagsOr")).thenReturn(null);
         when(mockHCExecutor.execute(any(HealthCheckExecutionOptions.class), anyString())).thenReturn(results);
 
@@ -112,16 +112,16 @@ public class HealthCheckExecutorServletTest {
         verify(printWriter,    times(1)).write(stringResultCaptor.capture());
         
         Assert.assertEquals("Should combine with OR", true, optionsCaptor.getValue().isCombineTagsWithOr());
-        Assert.assertEquals("Should provide a single tag", Arrays.asList("devops"), stringTagsCaptor.getAllValues());
+        Assert.assertEquals("Should provide a single tag", Arrays.asList("shallow"), stringTagsCaptor.getAllValues());
         Assert.assertEquals("Should be JSON object with one result", "{\"results\":[{\"name\":\"\",\"status\":\"OK\",\"timeMs\":0}]}", stringResultCaptor.getValue());
     }
     
     /**
-     * /system/health?tags=devops,security
+     * /system/health?tags=shallow,security
      */
     @Test
     public void testMultipleTags() throws Exception {
-        when(mockRequest.getParameter("tags")).thenReturn("devops,security");
+        when(mockRequest.getParameter("tags")).thenReturn("shallow,security");
         when(mockRequest.getParameter("combineTagsOr")).thenReturn(null);
 
         servlet.doGet(mockRequest, mockResponse);
@@ -133,16 +133,16 @@ public class HealthCheckExecutorServletTest {
         verify(printWriter,    times(1)).write(stringResultCaptor.capture());
         
         Assert.assertEquals("Should combine with OR", true, optionsCaptor.getValue().isCombineTagsWithOr());
-        Assert.assertEquals("Should provide two tags", Arrays.asList("devops", "security"), stringTagsCaptor.getAllValues());
+        Assert.assertEquals("Should provide two tags", Arrays.asList("shallow", "security"), stringTagsCaptor.getAllValues());
         Assert.assertEquals("Should be blank JSON array", "{\"results\":[]}", stringResultCaptor.getValue());
     }
     
     /**
-     * /system/health?tags=devops&combineTagsOr=false
+     * /system/health?tags=shallow&combineTagsOr=false
      */
     @Test
     public void testCombineTagsOrIsFalse() throws Exception {        
-        when(mockRequest.getParameter("tags")).thenReturn("devops");
+        when(mockRequest.getParameter("tags")).thenReturn("shallow");
         when(mockRequest.getParameter("combineTagsOr")).thenReturn("false");
 
         servlet.doGet(mockRequest, mockResponse);
@@ -154,7 +154,7 @@ public class HealthCheckExecutorServletTest {
         verify(printWriter,    times(1)).write(stringResultCaptor.capture());
         
         Assert.assertEquals("Should not combine with OR", false, optionsCaptor.getValue().isCombineTagsWithOr());
-        Assert.assertEquals("Should provide a single tags", Arrays.asList("devops"), stringTagsCaptor.getAllValues());
+        Assert.assertEquals("Should provide a single tags", Arrays.asList("shallow"), stringTagsCaptor.getAllValues());
         Assert.assertEquals("Should be blank JSON array", "{\"results\":[]}", stringResultCaptor.getValue());
     }
     


### PR DESCRIPTION
* Changed “devops” tag to “shallow” in the health check as well as in the documentation

* Kept “devops" tag to allow for backward compatibility